### PR TITLE
rbd: rbd-wnbd live resize support

### DIFF
--- a/src/tools/rbd_wnbd/rbd_wnbd.cc
+++ b/src/tools/rbd_wnbd/rbd_wnbd.cc
@@ -902,6 +902,54 @@ exit:
     }
 };
 
+class WNBDWatchCtx : public librbd::UpdateWatchCtx
+{
+private:
+  PWNBD_DISK disk;
+  WnbdHandler* handler;
+  librados::IoCtx &io_ctx;
+  librbd::Image &image;
+  uint64_t size;
+public:
+  WNBDWatchCtx(librados::IoCtx &_io_ctx,
+              WnbdHandler* handler,
+              librbd::Image &_image,
+              uint64_t _size)
+    : io_ctx(_io_ctx)
+    , handler(handler)
+    , image(_image)
+    , size(_size)
+  { }
+
+  ~WNBDWatchCtx() override {}
+
+  void handle_notify() override
+  {
+    librbd::image_info_t info;
+    if (image.stat(info, sizeof(info)) == 0) {
+      uint64_t new_size = info.size;
+      int ret;
+
+      if (new_size != size) {
+        dout(5) << "Resizing disk. Block size: " << RBD_WNBD_BLKSIZE
+                << ". New block count: "
+                << new_size / RBD_WNBD_BLKSIZE
+                << ". Old block count: "
+                << size / RBD_WNBD_BLKSIZE  << "." << dendl;
+        
+        ret = handler->resize(new_size / RBD_WNBD_BLKSIZE);
+
+        if (ret < 0)
+          derr << "resize failed: " << cpp_strerror(errno) << dendl;
+	      
+        if (!ret)
+          size = new_size;
+      }
+    }
+  }
+};
+
+
 static void usage()
 {
   const char* usage_str =R"(
@@ -1046,6 +1094,8 @@ static int do_map(Config *cfg)
   librbd::Image image;
   librbd::image_info_t info;
   HANDLE parent_pipe_handle = INVALID_HANDLE_VALUE;
+  uint64_t handle;
+  WNBDWatchCtx* watch_ctx = nullptr;
   int err = 0;
 
   if (g_conf()->daemonize && cfg->parent_pipe.empty()) {
@@ -1159,7 +1209,17 @@ static int do_map(Config *cfg)
     global_init_postfork_finish(g_ceph_context);
   }
 
+  watch_ctx = new WNBDWatchCtx(io_ctx, handler, image, info.size);
+  r = image.update_watch(watch_ctx, &handle);
+  if (r < 0)
+    goto close_ret;
+
   handler->wait();
+
+  r = image.update_unwatch(handle);
+  if (r < 0)
+    goto close_ret;
+
   handler->shutdown();
 
   // The registry record shouldn't be removed for (already) running mappings.
@@ -1182,6 +1242,10 @@ close_ret:
   if (handler) {
     delete handler;
     handler = nullptr;
+  }
+
+  if (watch_ctx) {
+    delete watch_ctx;
   }
 
   return r;

--- a/src/tools/rbd_wnbd/wnbd_handler.cc
+++ b/src/tools/rbd_wnbd/wnbd_handler.cc
@@ -367,6 +367,21 @@ void WnbdHandler::LogMessage(
           << WnbdLogLevelToStr(LogLevel) << " " << Message << dendl;
 }
 
+int WnbdHandler::resize(uint64_t block_count)
+{
+  int err = 0;
+
+  err = WnbdSetDiskSize(wnbd_disk, block_count);
+
+  if (err) {
+    derr << "WNBD: Setting disk size failed with error: "
+         << err << dendl;
+    return -EINVAL;
+  }
+  dout(5) << "Successfully resized disk to: " << block_count << " blocks" << dendl;
+
+  return err;
+}
 
 int WnbdHandler::start()
 {

--- a/src/tools/rbd_wnbd/wnbd_handler.h
+++ b/src/tools/rbd_wnbd/wnbd_handler.h
@@ -98,6 +98,7 @@ public:
     reply_tpool = new boost::asio::thread_pool(_io_reply_workers);
   }
 
+  int resize(uint64_t block_count);
   int start();
   // Wait for the handler to stop, which normally happens when the driver
   // passes the "Disconnect" request.


### PR DESCRIPTION
Added rbd-wnbd live resize support by propagating the rbd resize events to the WNBD driver.

Signed-off-by: Stefan Chivu <schivu@cloudbasesolutions.com>

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
